### PR TITLE
Improve waitlist form spacing

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -104,6 +104,41 @@ a:hover { text-decoration: underline }
 .billing-toggle button[data-active="true"] { background: rgba(255,255,255,.12); opacity: 1 }
 .cta-section { background: linear-gradient(180deg, rgba(255,255,255,.03), rgba(255,255,255,0)); border: 1px solid var(--border); border-radius: var(--card-radius); padding: 24px; display: grid; gap: 12px }
 .subtle { color: var(--muted) }
+#waitlistForm {
+  display: grid;
+  gap: 16px;
+}
+
+#waitlistForm .form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+#waitlistForm label {
+  display: grid;
+  gap: 6px;
+}
+
+#waitlistForm input,
+#waitlistForm select {
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: rgba(255,255,255,.04);
+  color: var(--text);
+}
+
+#waitlistForm .fine-print {
+  font-size: 12px;
+}
+
+#waitlistForm .form-actions {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+}
 footer { padding: 40px 0; color: var(--muted); border-top: 1px solid var(--border); margin-top: 40px }
 dialog { border: none; border-radius: 16px; padding: 0; width: min(680px, 92vw); background: color-mix(in oklab, var(--bg) 20%, white 8%); color: var(--text); box-shadow: var(--shadow); }
 dialog::backdrop { background: rgba(3,6,12,.6); backdrop-filter: blur(2px) }

--- a/pages/html-master-signup.html
+++ b/pages/html-master-signup.html
@@ -59,31 +59,31 @@
     <section id="signup" class="hero-card" aria-labelledby="subscribeTitle">
       <h2 id="subscribeTitle" style="margin:0 0 8px">Join the HTML Master waitlist</h2>
       <p class="subtle" style="margin-top:-4px">We’ll notify you when early access opens. Double opt‑in, one email max per week.</p>
-      <form id="waitlistForm" novalidate>
-        <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px">
-          <label>First name
-            <input id="name" name="name" autocomplete="given-name" />
+        <form id="waitlistForm" novalidate>
+          <div class="form-row">
+            <label>First name
+              <input id="name" name="name" autocomplete="given-name" />
+            </label>
+            <label>Email
+              <input id="email" name="email" type="email" autocomplete="email" required />
+            </label>
+          </div>
+          <label>Primary goal
+            <select id="useCase" name="useCase">
+              <option>Learn HTML basics</option>
+              <option>Fix my existing code</option>
+              <option>Ship a website</option>
+              <option>Teach students</option>
+            </select>
           </label>
-          <label>Email
-            <input id="email" name="email" type="email" autocomplete="email" required />
-          </label>
-        </div>
-        <label>Primary goal
-          <select id="useCase" name="useCase">
-            <option>Learn HTML basics</option>
-            <option>Fix my existing code</option>
-            <option>Ship a website</option>
-            <option>Teach students</option>
-          </select>
-        </label>
-        <input id="website" name="website" tabindex="-1" aria-hidden="true" style="position:absolute;left:-9999px;opacity:0" />
-        <div class="subtle" style="font-size:12px">By joining, you agree to our <a href="#">Terms</a> and <a href="#">Privacy</a>.</div>
-        <div style="display:flex;gap:10px;align-items:center;flex-wrap:wrap">
-          <button class="btn btn-primary" id="submitBtn" type="submit">Join waitlist</button>
-          <span id="formMsg" class="subtle" role="status" aria-live="polite"></span>
-        </div>
-      </form>
-    </section>
+          <input id="website" name="website" tabindex="-1" aria-hidden="true" style="position:absolute;left:-9999px;opacity:0" />
+          <div class="subtle fine-print">By joining, you agree to our <a href="#">Terms</a> and <a href="#">Privacy</a>.</div>
+          <div class="form-actions">
+            <button class="btn btn-primary" id="submitBtn" type="submit">Join waitlist</button>
+            <span id="formMsg" class="subtle" role="status" aria-live="polite"></span>
+          </div>
+        </form>
+      </section>
   </main>
 
   <footer class="container">


### PR DESCRIPTION
## Summary
- use grid and flex styles to space fields and actions in waitlist form
- replace inline styles with reusable classes for finer control

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8be123c088321ae149f110fffaa1f