### PR TITLE
Add detailed HTML Master description

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -16,6 +16,7 @@ function renderPills() {
 
 const cards = $('#cards');
 function personaDetails(p) {
+  if (p.details) return p.details;
   const cat = categories.find(c => c.id === p.category)?.label || p.category;
   return `<div class="subtle">Category: <strong>${cat}</strong></div>
           <p>${p.desc}</p>

--- a/assets/js/data.js
+++ b/assets/js/data.js
@@ -17,6 +17,20 @@ export const personas = [
     category: 'html',
     status: 'alpha',
     desc: 'Validate, tidy, and explain your markup. Perfect for beginners and production checklists.',
+    details: `
+      <p>Discover HTML Master – Your Interactive Path to Becoming an HTML Pro</p>
+      <p>Ready to finally master HTML without boring textbooks or endless tutorials? HTML Master is a hands-on, interactive course built right into your browser. From your very first tag to advanced, real-world projects, you’ll learn step by step while actually coding along the way.</p>
+      <h4>💡 Why learners love it:</h4>
+      <ul>
+        <li><strong>Learn by Doing:</strong> Every lesson includes live code editors, previews, and quizzes so you can instantly see your progress.</li>
+        <li><strong>Three Levels of Mastery:</strong> Start with the Basics, build confidence with Intermediate, and tackle real projects in the Advanced module.</li>
+        <li><strong>Track Your Progress:</strong> See exactly how far you’ve come with built-in progress tracking—your completions and quiz scores update automatically.</li>
+        <li><strong>Your AI Coding Buddy:</strong> Stuck on a concept? Our AI Assistant (powered by n8n) is right there in the chat widget, ready to answer your HTML questions in real time.</li>
+        <li><strong>Fair Credit System:</strong> The chat runs on Gasergy Credits, so you’re always in control. Need more? Recharge instantly with secure Stripe checkout.</li>
+      </ul>
+      <p><strong>🔒 Members-Only Access:</strong><br />Everything lives behind a simple login, so your progress and tools are saved just for you. Once you’re in, it’s your personal learning hub.</p>
+      <p>👉 Whether you’re brand new or looking to sharpen your skills, HTML Master makes learning fun, practical, and accessible.<br />Try it now and start coding your first project today!</p>
+    `,
     tags: ['validation', 'semantics', 'accessibility'],
     actions: ['try','details']
   },


### PR DESCRIPTION
## Summary
- Show rich description when viewing HTML Master details
- Support optional persona-specific detail content

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ef79190c8321b60986410688fcd4