### PR TITLE
Skip null children in DOM helper

### DIFF
--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -9,6 +9,7 @@ export function el(tag, attrs = {}, children = []) {
     else if (v !== undefined && v !== null) node.setAttribute(k, v);
   });
   for (const child of (Array.isArray(children) ? children : [children])) {
+    if (child == null) continue;
     node.append(child instanceof Node ? child : document.createTextNode(child));
   }
   return node;


### PR DESCRIPTION
## Summary
- Ignore `null` and `undefined` children in `el()` to prevent stray text nodes

## Testing
- `node verify.mjs` *(ensured persona cards without status no longer show "null" label)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5d08406c8321b9c036634bdfde9f