### PR TITLE
Add detailed HTML Master description

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -16,6 +16,7 @@ function renderPills() {
 
 const cards = $('#cards');
 function personaDetails(p) {
+  if (p.details) return p.details;
   const cat = categories.find(c => c.id === p.category)?.label || p.category;
   return `<div class="subtle">Category: <strong>${cat}</strong></div>
           <p>${p.desc}</p>

--- a/assets/js/data.js
+++ b/assets/js/data.js
@@ -17,6 +17,20 @@ export const personas = [
     category: 'html',
     status: 'alpha',
     desc: 'Validate, tidy, and explain your markup. Perfect for beginners and production checklists.',
+    details: `
+      <p>Discover HTML Master – Your Interactive Path to Becoming an HTML Pro</p>
+      <p>Ready to finally master HTML without boring textbooks or endless tutorials? HTML Master is a hands-on, interactive course built right into your browser. From your very first tag to advanced, real-world projects, you’ll learn step by step while actually coding along the way.</p>
+      <h4>💡 Why learners love it:</h4>
+      <ul>
+        <li><strong>Learn by Doing:</strong> Every lesson includes live code editors, previews, and quizzes so you can instantly see your progress.</li>
+        <li><strong>Three Levels of Mastery:</strong> Start with the Basics, build confidence with Intermediate, and tackle real projects in the Advanced module.</li>
+        <li><strong>Track Your Progress:</strong> See exactly how far you’ve come with built-in progress tracking—your completions and quiz scores update automatically.</li>
+        <li><strong>Your AI Coding Buddy:</strong> Stuck on a concept? Our AI Assistant (powered by n8n) is right there in the chat widget, ready to answer your HTML questions in real time.</li>
+        <li><strong>Fair Credit System:</strong> The chat runs on Gasergy Credits, so you’re always in control. Need more? Recharge instantly with secure Stripe checkout.</li>
+      </ul>
+      <p><strong>🔒 Members-Only Access:</strong><br />Everything lives behind a simple login, so your progress and tools are saved just for you. Once you’re in, it’s your personal learning hub.</p>
+      <p>👉 Whether you’re brand new or looking to sharpen your skills, HTML Master makes learning fun, practical, and accessible.<br />Try it now and start coding your first project today!</p>
+    `,
     tags: ['validation', 'semantics', 'accessibility'],
     actions: ['try','details']
   },

--- a/pages/html-master-signup.html
+++ b/pages/html-master-signup.html
@@ -4,9 +4,9 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>HTML Master • Join the Waitlist</title>
-  <meta name="description" content="Join the HTML Master waitlist — an AI mentor that validates, tidies, and explains your HTML line-by-line.">
-  <meta property="og:title" content="HTML Master — Your AI HTML mentor" />
-  <meta property="og:description" content="Validate, tidy, and learn HTML faster. Join the free waitlist." />
+    <meta name="description" content="Join the HTML Master waitlist — an interactive browser-based course with live coding, progress tracking, and an AI buddy." />
+    <meta property="og:title" content="HTML Master — Interactive HTML course" />
+    <meta property="og:description" content="Interactive HTML course with live editors, progress tracking, and AI help. Join the free waitlist." />
   <meta property="og:type" content="website" />
   <meta property="og:image" content="../assets/img/og-html-master.png" />
   <link rel="stylesheet" href="../assets/css/style.css">
@@ -25,8 +25,8 @@
   <header class="hero container">
     <div class="hero-grid">
       <div>
-        <h1>Learn HTML faster with <span class="gradient-text">HTML Master</span></h1>
-        <p class="subtle">Your AI mentor that <strong>validates</strong>, <strong>tidies</strong>, and <strong>explains</strong> your markup line‑by‑line — with accessibility tips built in.</p>
+          <h1>Discover <span class="gradient-text">HTML Master</span> — Your Interactive Path to HTML Pro</h1>
+          <p class="subtle">Hands‑on lessons in your browser with live code editors, progress tracking, and an AI coding buddy — all in your members‑only hub.</p>
         <div class="cta-row"><a href="#signup" class="btn btn-primary">Join free waitlist</a></div>
       </div>
       <aside>
@@ -40,7 +40,7 @@
   &lt;input id="email" type="email" required /&gt;
   &lt;button&gt;Join waitlist&lt;/button&gt;
 &lt;/form&gt;</code></pre>
-          <p class="subtle" style="margin-top:8px">Get instant feedback on semantics, labels, and errors.</p>
+          <p class="subtle" style="margin-top:8px">Practice live and get instant feedback from your AI buddy.</p>
         </div>
       </aside>
     </div>
@@ -50,9 +50,9 @@
     <section class="hero-card" style="margin-bottom:16px">
       <h2 style="margin:0 0 8px">What you’ll get</h2>
       <div class="grid">
-        <div class="col-4"><strong>Line‑by‑line explanations</strong><br><span class="subtle" style="font-size:12px">Understand what every tag does — in plain language.</span></div>
-        <div class="col-4"><strong>Instant validation</strong><br><span class="subtle" style="font-size:12px">Catch missing alt, improper nesting, and more.</span></div>
-        <div class="col-4"><strong>Production checklists</strong><br><span class="subtle" style="font-size:12px">SEO and accessibility reminders before you ship.</span></div>
+        <div class="col-4"><strong>Live coding &amp; quizzes</strong><br><span class="subtle" style="font-size:12px">Learn by doing with editors, previews, and challenges.</span></div>
+        <div class="col-4"><strong>Track your progress</strong><br><span class="subtle" style="font-size:12px">Completions and quiz scores update automatically.</span></div>
+        <div class="col-4"><strong>AI coding buddy</strong><br><span class="subtle" style="font-size:12px">Chat in real time whenever you need a hand.</span></div>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- Show rich description when viewing HTML Master details
- Support optional persona-specific detail content
- Align HTML Master waitlist landing copy with course description

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ef79190c8321b60986410688fcd4