### PR TITLE
Replace waitlist form with external signup link

### DIFF
--- a/pages/html-master-signup.html
+++ b/pages/html-master-signup.html
@@ -59,30 +59,7 @@
     <section id="signup" class="hero-card" aria-labelledby="subscribeTitle">
       <h2 id="subscribeTitle" style="margin:0 0 8px">Join the HTML Master waitlist</h2>
       <p class="subtle" style="margin-top:-4px">We’ll notify you when early access opens. Double opt‑in, one email max per week.</p>
-        <form id="waitlistForm" novalidate>
-          <div class="form-row">
-            <label>First name
-              <input id="name" name="name" autocomplete="given-name" />
-            </label>
-            <label>Email
-              <input id="email" name="email" type="email" autocomplete="email" required />
-            </label>
-          </div>
-          <label>Primary goal
-            <select id="useCase" name="useCase">
-              <option>Learn HTML basics</option>
-              <option>Fix my existing code</option>
-              <option>Ship a website</option>
-              <option>Teach students</option>
-            </select>
-          </label>
-          <input id="website" name="website" tabindex="-1" aria-hidden="true" style="position:absolute;left:-9999px;opacity:0" />
-          <div class="subtle fine-print">By joining, you agree to our <a href="#">Terms</a> and <a href="#">Privacy</a>.</div>
-          <div class="form-actions">
-            <button class="btn btn-primary" id="submitBtn" type="submit">Join waitlist</button>
-            <span id="formMsg" class="subtle" role="status" aria-live="polite"></span>
-          </div>
-        </form>
+        <a href="https://forms.gle/rzNbn5sev56UcupRA" target="_blank" rel="noopener" class="btn btn-primary" style="display:block;text-align:center;padding:16px;font-size:1.25rem;">Join Waitlist</a>
       </section>
   </main>
 
@@ -93,6 +70,5 @@
     </div>
   </footer>
 
-  <script type="module" src="../assets/js/signup.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove embedded waitlist form on HTML Master signup page
- add prominent "Join Waitlist" button linking to Google Form in a new tab
- drop unused signup script

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '.../package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68c086b85c8c83218cf0eccc9f5cceed