### PR TITLE
Link custom persona waitlist to Google Form

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,13 @@
       <h2>Create a <span class="gradient-text">custom AI persona</span></h2>
       <p class="lead">Design the tone, tools, and guardrails. Share it with your team — or with the world. <strong style="color:var(--warn)">Coming soon.</strong></p>
       <div class="cta-row">
-        <button class="btn btn-primary" id="joinWaitlist">Join Waitlist</button>
+        <a
+          href="https://forms.gle/jdXHYwVAL5miG11f7"
+          class="btn btn-primary"
+          id="joinWaitlist"
+          target="_blank"
+          rel="noopener"
+        >Join Waitlist</a>
         <!-- <button class="btn btn-ghost" id="watchDemo">Watch concept demo</button> -->
         <span class="subtle">We’ll email you when the builder opens.</span>
       </div>


### PR DESCRIPTION
## Summary
- Link Custom AI Persona builder's Join Waitlist button to a Google Form and open in a new tab.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ea0d96288321837c7fd3d315f149