### PR TITLE
feat: add pre-launch gasergy pricing

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -101,38 +101,18 @@ function openInfo(title, html) {
 }
 window.openInfo = openInfo;
 
-const monthly = { starter: 5, pro: 19, power: 49 };
-const annual  = { starter: 50, pro: 190, power: 490 }; // 2 months free
-let billing = 'monthly';
-function updatePrices() {
-  $$('.price-card').forEach(card => {
-    const plan = card.dataset.plan;
-    const priceEl = card.querySelector('[data-price]');
-    const noteEl = card.querySelector('[data-credits]');
-    const value = billing === 'monthly' ? monthly[plan] : annual[plan];
-    priceEl.innerHTML = `$${value}<span class="subtle">/${billing==='monthly'?'mo':'yr'}</span>`;
-    noteEl.textContent = billing === 'monthly' ? noteEl.textContent.replace(/\d+(,\d{3})* credits \/ month/g, noteEl.textContent.match(/\d+(,\d{3})* credits \/ month/)?.[0] || '') : noteEl.textContent.replace(' / month',' / year');
+  const buyModal = $('#buyModal');
+  $$('.price-card [data-buy]').forEach(btn => btn.addEventListener('click', () => {
+    const plan = btn.getAttribute('data-buy');
+    $('#buyPlan').value = plan;
+    buyModal.showModal();
+  }));
+  $('#buyNow')?.addEventListener('click', () => {
+    const plan = $('#buyPlan').value; const email = $('#buyEmail').value.trim();
+    if (!email || !/^[^\@\s]+@[^\@\s]+\.[^\@\s]+$/.test(email)) { alert('Please enter a valid email'); return; }
+    alert(`(Placeholder) Proceeding to checkout for ${plan.toUpperCase()}. Connect to Stripe later.`);
+    buyModal.close();
   });
-  $('#billMonthly').dataset.active = String(billing==='monthly');
-  $('#billAnnual').dataset.active  = String(billing!=='monthly');
-  $('#billMonthly').setAttribute('aria-selected', String(billing==='monthly'));
-  $('#billAnnual').setAttribute('aria-selected', String(billing!=='monthly'));
-}
-$('#billMonthly')?.addEventListener('click', () => { billing = 'monthly'; updatePrices(); });
-$('#billAnnual')?.addEventListener('click', () => { billing = 'annual'; updatePrices(); });
-
-const buyModal = $('#buyModal');
-$$('.price-card [data-buy]').forEach(btn => btn.addEventListener('click', () => {
-  const plan = btn.getAttribute('data-buy');
-  $('#buyPlan').value = plan;
-  buyModal.showModal();
-}));
-$('#buyNow')?.addEventListener('click', () => {
-  const plan = $('#buyPlan').value; const email = $('#buyEmail').value.trim();
-  if (!email || !/^[^\@\s]+@[^\@\s]+\.[^\@\s]+$/.test(email)) { alert('Please enter a valid email'); return; }
-  alert(`(Placeholder) Proceeding to checkout for ${plan.toUpperCase()} — ${billing==='monthly'?'monthly':'annual'} billing. Connect to Stripe later.`);
-  buyModal.close();
-});
 
 document.querySelectorAll('[data-details]').forEach(b => b.addEventListener('click', () => {
   const id = b.getAttribute('data-details');
@@ -145,9 +125,8 @@ $('#siGo')?.addEventListener('click', () => { alert('Signed in (placeholder). Ho
 
 const yearEl = document.getElementById('year'); if (yearEl) yearEl.textContent = new Date().getFullYear();
 
-if (pillbar && cards) {
-  renderPills();
-  renderCards();
-  updatePrices();
-}
+  if (pillbar && cards) {
+    renderPills();
+    renderCards();
+  }
 window.addEventListener('keydown', (e) => { if (e.key === 'Escape') document.querySelectorAll('dialog').forEach(d => d.open && d.close()); });

--- a/index.html
+++ b/index.html
@@ -86,67 +86,89 @@
   </section>
 
   <section id="pricing" class="section container">
-    <div style="display:flex; align-items:center; justify-content:space-between; gap:12px; flex-wrap:wrap">
-      <div>
-        <h2>Monthly Gasergy credits</h2>
-        <p class="lead">Simple, transparent plans. Credits renew every month — upgrade anytime.</p>
+  <div>
+    <h2>Pre-launch Gasergy credits</h2>
+    <p class="lead">Lock in 50% off during pre-launch. Credits renew per your plan.</p>
+    <p class="subtle" style="margin-top:8px"><strong>Note:</strong> SRN is still pre-launch and some products may not be available yet. Buying Gasergy now secures this discount before prices return to normal at launch.</p>
+  </div>
+
+  <h3 style="margin-top:24px">Monthly subscriptions</h3>
+  <div class="pricing" style="margin-top:14px">
+    <article class="price-card" data-plan="business-monthly" aria-labelledby="businessMonthlyTitle">
+      <div class="chip">50% off</div>
+      <h3 id="businessMonthlyTitle">Business</h3>
+      <div class="price">$14.79<span class="subtle">/mo</span></div>
+      <div class="note">500&nbsp;G / month</div>
+      <div class="actions">
+        <button class="btn btn-primary" data-buy="business-monthly">Buy Business</button>
       </div>
-      <div class="billing-toggle" role="tablist" aria-label="Billing period">
-        <button id="billMonthly" data-active="true" aria-selected="true">Monthly</button>
-        <button id="billAnnual" aria-selected="false">Annual <span class="chip" style="margin-left:6px">2 months free</span></button>
+    </article>
+
+    <article class="price-card" data-plan="enterprise-monthly" aria-labelledby="enterpriseMonthlyTitle">
+      <div class="chip">50% off</div>
+      <h3 id="enterpriseMonthlyTitle">Enterprise</h3>
+      <div class="price">$61.99<span class="subtle">/mo</span></div>
+      <div class="note">10,000&nbsp;G / month</div>
+      <div class="actions">
+        <button class="btn btn-primary" data-buy="enterprise-monthly">Buy Enterprise</button>
       </div>
-    </div>
+    </article>
 
-    <div class="pricing" style="margin-top:14px">
-      <article class="price-card" data-plan="starter" aria-labelledby="starterTitle">
-        <div class="chip">Best for trying</div>
-        <h3 id="starterTitle">Starter</h3>
-        <div class="price" data-price>$5<span class="subtle">/mo</span></div>
-        <div class="note" data-credits>500 credits / month</div>
-        <ul class="features">
-          <li>✔️ Try every coding bot</li>
-          <li>✔️ Light usage across projects</li>
-          <li>✔️ Community support</li>
-        </ul>
-        <div class="actions">
-          <button class="btn btn-primary" data-buy="starter">Buy Starter</button>
-          <button class="btn btn-ghost" data-open-details="credits">How credits work</button>
-        </div>
-      </article>
+    <article class="price-card" data-plan="professional-monthly" aria-labelledby="professionalMonthlyTitle">
+      <div class="chip">50% off</div>
+      <h3 id="professionalMonthlyTitle">Professional</h3>
+      <div class="price">$17.99<span class="subtle">/mo</span></div>
+      <div class="note">2,500&nbsp;G / month</div>
+      <div class="actions">
+        <button class="btn btn-primary" data-buy="professional-monthly">Buy Professional</button>
+      </div>
+    </article>
 
-      <article class="price-card" data-plan="pro" aria-labelledby="proTitle">
-        <div class="chip" style="border-color:transparent; background:rgba(0,0,0,.2);">Most popular</div>
-        <h3 id="proTitle">Pro</h3>
-        <div class="price" data-price>$19<span class="subtle">/mo</span></div>
-        <div class="note" data-credits>3,000 credits / month</div>
-        <ul class="features">
-          <li>✔️ Everything in Starter</li>
-          <li>✔️ Priority queue</li>
-          <li>✔️ Early access to new personas</li>
-        </ul>
-        <div class="actions">
-          <button class="btn btn-primary" data-buy="pro">Buy Pro</button>
-          <button class="btn btn-ghost" data-open-details="credits">How credits work</button>
-        </div>
-      </article>
+    <article class="price-card" data-plan="starter-monthly" aria-labelledby="starterMonthlyTitle">
+      <div class="chip">50% off</div>
+      <h3 id="starterMonthlyTitle">Starter</h3>
+      <div class="price">$1.79<span class="subtle">/mo</span></div>
+      <div class="note">500&nbsp;G / month</div>
+      <div class="actions">
+        <button class="btn btn-primary" data-buy="starter-monthly">Buy Starter</button>
+      </div>
+    </article>
+  </div>
 
-      <article class="price-card" data-plan="power" aria-labelledby="powerTitle">
-        <div class="chip" style="border-color:transparent; background:rgba(0,0,0,.2); color:#b7ffbf">For power users</div>
-        <h3 id="powerTitle">Power</h3>
-        <div class="price" data-price>$49<span class="subtle">/mo</span></div>
-        <div class="note" data-credits>10,000 credits / month</div>
-        <ul class="features">
-          <li>✔️ Everything in Pro</li>
-          <li>✔️ Priority support</li>
-          <li>✔️ Team seats (coming soon)</li>
-        </ul>
-        <div class="actions">
-          <button class="btn btn-primary" data-buy="power">Buy Power</button>
-          <button class="btn btn-ghost" data-open-details="credits">How credits work</button>
-        </div>
-      </article>
-    </div>
-  </section>
+  <h3 style="margin-top:24px">Annual subscriptions</h3>
+  <div class="pricing" style="margin-top:14px">
+    <article class="price-card" data-plan="enterprise-annual" aria-labelledby="enterpriseAnnualTitle">
+      <div class="chip">Annual • 50% off</div>
+      <h3 id="enterpriseAnnualTitle">Enterprise</h3>
+      <div class="price">$749.99<span class="subtle">/yr</span></div>
+      <div class="note">50,000&nbsp;G / year</div>
+      <div class="actions">
+        <button class="btn btn-primary" data-buy="enterprise-annual">Buy Enterprise Annual</button>
+      </div>
+    </article>
+
+    <article class="price-card" data-plan="business-annual" aria-labelledby="businessAnnualTitle">
+      <div class="chip">Annual • 50% off</div>
+      <h3 id="businessAnnualTitle">Business</h3>
+      <div class="price">$179.99<span class="subtle">/yr</span></div>
+      <div class="note">10,000&nbsp;G / year</div>
+      <div class="actions">
+        <button class="btn btn-primary" data-buy="business-annual">Buy Business Annual</button>
+      </div>
+    </article>
+
+    <article class="price-card" data-plan="professional-annual" aria-labelledby="professionalAnnualTitle">
+      <div class="chip">Annual • 50% off</div>
+      <h3 id="professionalAnnualTitle">Professional</h3>
+      <div class="price">$59.99<span class="subtle">/yr</span></div>
+      <div class="note">2,500&nbsp;G / year</div>
+      <div class="actions">
+        <button class="btn btn-primary" data-buy="professional-annual">Buy Professional Annual</button>
+      </div>
+    </article>
+  </div>
+</section>
+
 
   <section id="faq" class="section container">
     <h2>FAQ</h2>
@@ -203,11 +225,15 @@
       <div class="subtle">Checkout is a placeholder — connect Stripe/credits when you’re ready.</div>
       <div style="display:grid; gap:10px">
         <label>Plan
-          <select id="buyPlan" style="width:100%; padding:10px 12px; border-radius:12px; border:1px solid var(--border); background:rgba(255,255,255,.04); color:var(--text)">
-            <option value="starter">Starter — $5 / 500 credits</option>
-            <option value="pro">Pro — $19 / 3,000 credits</option>
-            <option value="power">Power — $49 / 10,000 credits</option>
-          </select>
+            <select id="buyPlan" style="width:100%; padding:10px 12px; border-radius:12px; border:1px solid var(--border); background:rgba(255,255,255,.04); color:var(--text)">
+              <option value="business-monthly">Business — $14.79 / 500 G per month</option>
+              <option value="enterprise-monthly">Enterprise — $61.99 / 10,000 G per month</option>
+              <option value="professional-monthly">Professional — $17.99 / 2,500 G per month</option>
+              <option value="starter-monthly">Starter — $1.79 / 500 G per month</option>
+              <option value="enterprise-annual">Enterprise Annual — $749.99 / 50,000 G per year</option>
+              <option value="business-annual">Business Annual — $179.99 / 10,000 G per year</option>
+              <option value="professional-annual">Professional Annual — $59.99 / 2,500 G per year</option>
+            </select>
         </label>
         <label>Email
           <input id="buyEmail" placeholder="you@example.com" style="width:100%; padding:10px 12px; border-radius:12px; border:1px solid var(--border); background:rgba(255,255,255,.04); color:var(--text)" />


### PR DESCRIPTION
## Summary
- show pre-launch gasergy pricing with 50% off tiers
- warn users about limited product availability and that prices will rise after launch
- simplify pricing script and checkout options

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f9d46a6c8321a7d74cecb76056da