### PR TITLE
Fix pricing toggle for annual and monthly cards

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -16,6 +16,7 @@
   --maxw: 1120px;
 }
 * { box-sizing: border-box }
+[hidden] { display: none !important }
 html, body { height: 100% }
 body {
   margin: 0;


### PR DESCRIPTION
## Summary
- Ensure elements with `hidden` attribute are not displayed so pricing tabs toggle correctly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c23ff3f27c8321a5e3b12ec759d3a5