### PR TITLE
feat: Add app_id tracking for user signups

### DIFF
--- a/stripe/create_checkout_session.php
+++ b/stripe/create_checkout_session.php
@@ -59,7 +59,8 @@ try {
         'cancel_url'  => $baseUrl . '/index.html', // Redirect to home page on cancellation
         'client_reference_id' => $_SESSION['user_id'], // Link the session to the logged-in user
         'metadata' => [
-            'gasergy_amount' => $gasergyAmount // Pass gasergy amount for webhook and success page
+            'gasergy_amount' => $gasergyAmount, // Pass gasergy amount for webhook and success page
+            'app_id' => 'main_site' // Track the application source
         ],
     ]);
 


### PR DESCRIPTION
This change introduces the ability to track which application a user signs up from.

The Stripe checkout session is modified to include an `app_id` in its metadata. The Stripe webhook is updated to read this `app_id` and store it in a new `app_id` column in the `users` table upon successful checkout.

For the main site, the `app_id` is hardcoded as 'main_site'.