### PR TITLE
feat: Add CTA button for Gasergy page

### DIFF
--- a/index.php
+++ b/index.php
@@ -109,6 +109,15 @@ if ($is_logged_in) {
     </div>
   </section>
 
+  <section id="pricing-cta" class="section container">
+    <div class="cta-section">
+        <h2>Ready to power up?</h2>
+        <p class="lead">Purchase Gasergy credits to unlock the full potential of your AI agents.</p>
+        <div class="cta-row">
+            <a href="pages/buy-gasergy.php" class="btn btn-primary" style="font-size: 1.2rem; padding: 1rem 2rem;">Buy Gasergy Credits</a>
+        </div>
+    </div>
+  </section>
 
   <section id="faq" class="section container">
     <h2>FAQ</h2>


### PR DESCRIPTION
Adds a new call-to-action section on the main `index.php` page with a large, prominent button that links to the new `pages/buy-gasergy.php` page.

This provides a clear and visually appealing link for users to navigate to the Gasergy purchasing page, as requested in the follow-up. The button is styled to match the existing site design.