### PR TITLE
Fix: Correct auth redirect path from buy-gasergy page

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -126,7 +126,8 @@ const checkoutForm = $('#checkout-form');
 // Handle clicking a "Buy" button on a pricing card
 $$('.price-card [data-buy]').forEach(btn => btn.addEventListener('click', () => {
   if (!window.isUserLoggedIn) {
-    window.location.href = 'auth.html?notice=login_required';
+    const basePath = document.body.dataset.basePath || './';
+    window.location.href = `${basePath}auth.html?notice=login_required`;
     return;
   }
   const plan = btn.getAttribute('data-buy');

--- a/index.php
+++ b/index.php
@@ -26,7 +26,7 @@ if ($is_logged_in) {
   <meta name="description" content="Meet SRN — a network of AI agent personas you can try, customize, and power with monthly credits.">
   <link rel="stylesheet" href="assets/css/style.css">
 </head>
-<body>
+<body data-base-path="./">
   <nav class="nav">
     <div class="container nav-inner">
       <div class="brand">

--- a/pages/buy-gasergy.php
+++ b/pages/buy-gasergy.php
@@ -27,7 +27,7 @@ if ($is_logged_in) {
   <meta name="description" content="Purchase Gasergy credits to power your AI agent personas on the SRN network.">
   <link rel="stylesheet" href="../assets/css/style.css">
 </head>
-<body>
+<body data-base-path="../">
   <nav class="nav">
     <div class="container nav-inner">
       <a href="../index.php" class="brand">


### PR DESCRIPTION
The login/create account flow was not being triggered correctly from the `buy-gasergy.php` page because the redirect path to `auth.html` was incorrect.

This was fixed by:
1. Adding a `data-base-path` attribute to the `<body>` tag in both `index.php` and `pages/buy-gasergy.php` to indicate the relative path to the root.
2. Updating `assets/js/app.js` to use this `data-base-path` attribute to construct the correct URL for the redirect, ensuring it works from any page.