### PR TITLE
feat: Add 500 error logging to Stripe webhook

### DIFF
--- a/stripe/webhook.php
+++ b/stripe/webhook.php
@@ -1,10 +1,12 @@
 <?php
 require_once __DIR__ . '/../config/logging.php';
+
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../config/db.php';
 require_once __DIR__ . '/../config/stripe.php';
 
-$payload = @file_get_contents('php://input');
+try {
+    $payload = @file_get_contents('php://input');
 $sigHeader = $_SERVER['HTTP_STRIPE_SIGNATURE'] ?? '';
 
 // Verify the webhook signature
@@ -151,3 +153,9 @@ switch ($event->type) {
 }
 
 http_response_code(200);
+} catch (\Throwable $e) {
+    http_response_code(500);
+    custom_log("FATAL Error: " . $e->getMessage() . "\n" . $e->getTraceAsString(), 'stripe_webhook.log');
+    // We can exit here, as the response code has been set and the error logged.
+    exit;
+}


### PR DESCRIPTION
This change introduces comprehensive error handling to the `stripe/webhook.php` script to ensure that any exceptions or fatal errors that would result in a 500 HTTP status code are caught and logged.

The entire webhook processing logic is now wrapped in a `try...catch (\Throwable $e)` block. If any `Throwable` is caught, the script will set the HTTP response code to 500, log a detailed error message to `stripe_webhook.log`, and then terminate execution.