### PR TITLE
Add subscription management link on buy page

### DIFF
--- a/pages/buy-gasergy.php
+++ b/pages/buy-gasergy.php
@@ -58,6 +58,9 @@ if ($is_logged_in) {
       <h2>Pre-launch Gasergy credits</h2>
       <p class="lead">Lock in 50% off during pre-launch. Credits renew per your plan.</p>
       <p class="subtle" style="margin-top:8px"><strong>Note:</strong> SRN is still pre-launch and some products may not be available yet. Buying Gasergy now secures this discount before prices return to normal at launch.</p>
+      <p style="margin-top:16px">
+        <a class="btn btn-ghost" href="https://billing.stripe.com/p/login/test_00wbJ12SW34q2cK1O10sU00" target="_blank" rel="noopener">Manage your subscription</a>
+      </p>
     </div>
 
     <div class="billing-toggle" role="tablist" aria-label="Billing period" style="margin-top:20px">


### PR DESCRIPTION
## Summary
- add a subscription management button to the buy Gasergy page linking to Stripe's customer portal

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dca7a0ef488321a3613231f7f54bc7